### PR TITLE
Subscriber Type Parameter extends Message

### DIFF
--- a/rosjava/src/main/java/org/ros/node/topic/CountDownSubscriberListener.java
+++ b/rosjava/src/main/java/org/ros/node/topic/CountDownSubscriberListener.java
@@ -16,6 +16,7 @@
 
 package org.ros.node.topic;
 
+import org.ros.internal.message.Message;
 import org.ros.internal.node.topic.PublisherIdentifier;
 
 import org.ros.internal.node.CountDownRegistrantListener;
@@ -29,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  * 
  * @author khughes@google.com (Keith M. Hughes)
  */
-public class CountDownSubscriberListener<T> extends CountDownRegistrantListener<Subscriber<T>>
+public class CountDownSubscriberListener<T extends Message> extends CountDownRegistrantListener<Subscriber<T>>
     implements SubscriberListener<T> {
 
   private final CountDownLatch shutdownLatch;
@@ -38,7 +39,7 @@ public class CountDownSubscriberListener<T> extends CountDownRegistrantListener<
   /**
    * Construct a {@link CountDownSubscriberListener} with all counts set to 1.
    */
-  public static <T> CountDownSubscriberListener<T> newDefault() {
+  public static <T extends Message> CountDownSubscriberListener<T> newDefault() {
     return newFromCounts(1, 1, 1, 1, 1);
   }
 
@@ -52,13 +53,13 @@ public class CountDownSubscriberListener<T> extends CountDownRegistrantListener<
    * @param masterUnregistrationFailureCount
    *          the number of failing master unregistrations to wait for
    * @param newSubscriberCount
-   *          the number of counts to wait for for a new publisher
+   *          the number of counts to wait for, for a new publisher
    */
-  public static <T> CountDownSubscriberListener<T> newFromCounts(
+  public static <T extends Message> CountDownSubscriberListener<T> newFromCounts(
       int masterRegistrationSuccessCount, int masterRegistrationFailureCount,
       int masterUnregistrationSuccessCount, int masterUnregistrationFailureCount,
       int newSubscriberCount) {
-    return new CountDownSubscriberListener<T>(new CountDownLatch(masterRegistrationSuccessCount),
+    return new CountDownSubscriberListener<T >(new CountDownLatch(masterRegistrationSuccessCount),
         new CountDownLatch(masterRegistrationFailureCount), new CountDownLatch(
             masterUnregistrationSuccessCount),
         new CountDownLatch(masterUnregistrationFailureCount),

--- a/rosjava/src/main/java/org/ros/node/topic/DefaultSubscriberListener.java
+++ b/rosjava/src/main/java/org/ros/node/topic/DefaultSubscriberListener.java
@@ -16,6 +16,7 @@
 
 package org.ros.node.topic;
 
+import org.ros.internal.message.Message;
 import org.ros.internal.node.topic.PublisherIdentifier;
 
 /**
@@ -23,7 +24,7 @@ import org.ros.internal.node.topic.PublisherIdentifier;
  * 
  * @author khughes@google.com (Keith M. Hughes)
  */
-public class DefaultSubscriberListener<T> implements SubscriberListener<T> {
+public class DefaultSubscriberListener<T extends Message> implements SubscriberListener<T> {
 
   @Override
   public void onMasterRegistrationSuccess(Subscriber<T> subscriber) {

--- a/rosjava/src/main/java/org/ros/node/topic/Subscriber.java
+++ b/rosjava/src/main/java/org/ros/node/topic/Subscriber.java
@@ -16,6 +16,7 @@
 
 package org.ros.node.topic;
 
+import org.ros.internal.message.Message;
 import org.ros.internal.node.topic.TopicParticipant;
 import org.ros.message.MessageListener;
 
@@ -30,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * @param <T>
  *          the {@link Subscriber} may only subscribe to messages of this type
  */
-public interface Subscriber<T> extends TopicParticipant {
+public interface Subscriber<T extends Message> extends TopicParticipant {
 
   /**
    * The message type given when a {@link Subscriber} chooses not to commit to a

--- a/rosjava/src/main/java/org/ros/node/topic/SubscriberListener.java
+++ b/rosjava/src/main/java/org/ros/node/topic/SubscriberListener.java
@@ -16,6 +16,7 @@
 
 package org.ros.node.topic;
 
+import org.ros.internal.message.Message;
 import org.ros.internal.node.RegistrantListener;
 import org.ros.internal.node.topic.PublisherIdentifier;
 
@@ -24,7 +25,7 @@ import org.ros.internal.node.topic.PublisherIdentifier;
  * 
  * @author khughes@google.com (Keith M. Hughes)
  */
-public interface SubscriberListener<T> extends RegistrantListener<Subscriber<T>> {
+public interface SubscriberListener<T extends Message> extends RegistrantListener<Subscriber<T>> {
 
   /**
    * A new {@link Publisher} has connected to the {@link Subscriber}.


### PR DESCRIPTION
Makes it easier for the user of the API to understand what type parameters are expected.