### PR TITLE
Replace topic message factory

### DIFF
--- a/docs/src/main/sphinx/getting_started.rst
+++ b/docs/src/main/sphinx/getting_started.rst
@@ -266,7 +266,7 @@ the underlying message implementation to change in the future. ::
 
   ...
 
-  PointCloud2 msg = node.getTopicMessageFactory()
+  PointCloud2 msg = node.getDefaultMessageFactory()
       .newMessage(sensor_msgs.PointCloud._TYPE);
 
 If you want to use messages that you define, whether they are officially released packages or your

--- a/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
+++ b/rosjava/src/main/java/org/ros/internal/node/DefaultNode.java
@@ -146,7 +146,7 @@ public class DefaultNode implements ConnectedNode {
 
         this.publisherFactory =
                 new PublisherFactory(nodeIdentifier, this.topicParticipantManager,
-                        nodeConfiguration.getTopicMessageFactory(), scheduledExecutorService);
+                        nodeConfiguration.getDefaultMessageFactory(), scheduledExecutorService);
         this.subscriberFactory =
                 new SubscriberFactory(nodeIdentifier, this.topicParticipantManager, scheduledExecutorService);
         this.serviceFactory =
@@ -472,8 +472,8 @@ public class DefaultNode implements ConnectedNode {
     }
 
     @Override
-    public MessageFactory getTopicMessageFactory() {
-        return this.nodeConfiguration.getTopicMessageFactory();
+    public MessageFactory getDefaultMessageFactory() {
+        return this.nodeConfiguration.getDefaultMessageFactory();
     }
 
     @Override

--- a/rosjava/src/main/java/org/ros/node/Node.java
+++ b/rosjava/src/main/java/org/ros/node/Node.java
@@ -84,7 +84,7 @@ public interface Node {
   /**
    * @return the {@link MessageFactory} used by this node
    */
-  MessageFactory getTopicMessageFactory();
+  MessageFactory getDefaultMessageFactory();
 
   /**
    * @return the {@link MessageFactory} used by this node for service responses

--- a/rosjava/src/main/java/org/ros/node/NodeConfiguration.java
+++ b/rosjava/src/main/java/org/ros/node/NodeConfiguration.java
@@ -76,7 +76,7 @@ public class NodeConfiguration {
   private List<File> rosPackagePath;
   private GraphName nodeName;
   private TopicDescriptionFactory topicDescriptionFactory;
-  private MessageFactory topicMessageFactory;
+  private MessageFactory defaultMessageFactory;
   private ServiceDescriptionFactory serviceDescriptionFactory;
   private MessageFactory serviceRequestMessageFactory;
   private MessageFactory serviceResponseMessageFactory;
@@ -101,7 +101,7 @@ public class NodeConfiguration {
     copy.rosPackagePath = nodeConfiguration.rosPackagePath;
     copy.nodeName = nodeConfiguration.nodeName;
     copy.topicDescriptionFactory = nodeConfiguration.topicDescriptionFactory;
-    copy.topicMessageFactory = nodeConfiguration.topicMessageFactory;
+    copy.defaultMessageFactory = nodeConfiguration.defaultMessageFactory;
     copy.serviceDescriptionFactory = nodeConfiguration.serviceDescriptionFactory;
     copy.serviceRequestMessageFactory = nodeConfiguration.serviceRequestMessageFactory;
     copy.serviceResponseMessageFactory = nodeConfiguration.serviceResponseMessageFactory;
@@ -182,7 +182,7 @@ public class NodeConfiguration {
   private NodeConfiguration() {
     MessageDefinitionProvider messageDefinitionProvider = new MessageDefinitionReflectionProvider();
     setTopicDescriptionFactory(new TopicDescriptionFactory(messageDefinitionProvider));
-    setTopicMessageFactory(new DefaultMessageFactory(messageDefinitionProvider));
+    setDefaultMessageFactory(new DefaultMessageFactory(messageDefinitionProvider));
     setServiceDescriptionFactory(new ServiceDescriptionFactory(messageDefinitionProvider));
     setServiceRequestMessageFactory(new ServiceRequestMessageFactory(messageDefinitionProvider));
     setServiceResponseMessageFactory(new ServiceResponseMessageFactory(messageDefinitionProvider));
@@ -359,17 +359,17 @@ public class NodeConfiguration {
   }
 
   /**
-   * @param topicMessageFactory
+   * @param defaultMessageFactory
    *          the {@link MessageFactory} for the {@link Node}
    * @return this {@link NodeConfiguration}
    */
-  public NodeConfiguration setTopicMessageFactory(MessageFactory topicMessageFactory) {
-    this.topicMessageFactory = topicMessageFactory;
+  public NodeConfiguration setDefaultMessageFactory(MessageFactory defaultMessageFactory) {
+    this.defaultMessageFactory = defaultMessageFactory;
     return this;
   }
 
-  public MessageFactory getTopicMessageFactory() {
-    return topicMessageFactory;
+  public MessageFactory getDefaultMessageFactory() {
+    return defaultMessageFactory;
   }
 
   /**

--- a/rosjava/src/test/java/org/ros/internal/transport/MessageQueueIntegrationTest.java
+++ b/rosjava/src/test/java/org/ros/internal/transport/MessageQueueIntegrationTest.java
@@ -37,10 +37,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.ros.concurrent.CancellableLoop;
 import org.ros.internal.message.DefaultMessageDeserializer;
+import org.ros.internal.message.DefaultMessageFactory;
 import org.ros.internal.message.DefaultMessageSerializer;
 import org.ros.internal.message.Message;
 import org.ros.internal.message.definition.MessageDefinitionReflectionProvider;
-import org.ros.internal.message.topic.TopicMessageFactory;
 import org.ros.internal.node.service.ServiceManager;
 import org.ros.internal.node.topic.TopicParticipantManager;
 import org.ros.internal.transport.queue.IncomingMessageQueue;
@@ -113,17 +113,17 @@ public class MessageQueueIntegrationTest {
   public void setup() {
     executorService = Executors.newCachedThreadPool();
     MessageDefinitionProvider messageDefinitionProvider = new MessageDefinitionReflectionProvider();
-    TopicMessageFactory topicMessageFactory = new TopicMessageFactory(messageDefinitionProvider);
-    expectedMessage = topicMessageFactory.newFromType(std_msgs.String._TYPE);
+    final DefaultMessageFactory defaultMessageFactory = new DefaultMessageFactory(messageDefinitionProvider);
+    expectedMessage = defaultMessageFactory.newFromType(std_msgs.String._TYPE);
     expectedMessage.setData("Would you like to play a game?");
     outgoingMessageQueue =
         new OutgoingMessageQueue<Message>(new DefaultMessageSerializer(), executorService);
     firstIncomingMessageQueue =
         new IncomingMessageQueue<std_msgs.String>(new DefaultMessageDeserializer<std_msgs.String>(
-            MessageIdentifier.of(std_msgs.String._TYPE), topicMessageFactory), executorService);
+            MessageIdentifier.of(std_msgs.String._TYPE), defaultMessageFactory), executorService);
     secondIncomingMessageQueue =
         new IncomingMessageQueue<std_msgs.String>(new DefaultMessageDeserializer<std_msgs.String>(
-            MessageIdentifier.of(std_msgs.String._TYPE), topicMessageFactory), executorService);
+            MessageIdentifier.of(std_msgs.String._TYPE), defaultMessageFactory), executorService);
     firstTcpClientManager = new TcpClientManager(executorService);
     firstTcpClientManager.addNamedChannelHandler(firstIncomingMessageQueue.getMessageReceiver());
     secondTcpClientManager = new TcpClientManager(executorService);

--- a/rosjava/src/test/java/org/ros/node/topic/TopicIntegrationTest.java
+++ b/rosjava/src/test/java/org/ros/node/topic/TopicIntegrationTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.ros.RosTest;
 import org.ros.concurrent.CancellableLoop;
+import org.ros.internal.message.DefaultMessageFactory;
 import org.ros.internal.message.definition.MessageDefinitionReflectionProvider;
-import org.ros.internal.message.topic.TopicMessageFactory;
 import org.ros.internal.node.topic.DefaultSubscriber;
 import org.ros.internal.node.topic.PublisherIdentifier;
 import org.ros.message.MessageDefinitionProvider;
@@ -50,8 +50,8 @@ public class TopicIntegrationTest extends RosTest {
 
   public TopicIntegrationTest() {
     MessageDefinitionProvider messageDefinitionProvider = new MessageDefinitionReflectionProvider();
-    TopicMessageFactory topicMessageFactory = new TopicMessageFactory(messageDefinitionProvider);
-    expectedMessage = topicMessageFactory.newFromType(std_msgs.String._TYPE);
+    DefaultMessageFactory defaultMessageFactory = new DefaultMessageFactory(messageDefinitionProvider);
+    expectedMessage = defaultMessageFactory.newFromType(std_msgs.String._TYPE);
     expectedMessage.setData("Would you like to play a game?");
   }
 
@@ -216,7 +216,7 @@ public class TopicIntegrationTest extends RosTest {
           @Override
           public void loop() throws InterruptedException {
             rosjava_test_msgs.TestHeader message =
-                connectedNode.getTopicMessageFactory().newFromType(rosjava_test_msgs.TestHeader._TYPE);
+                connectedNode.getDefaultMessageFactory().newFromType(rosjava_test_msgs.TestHeader._TYPE);
             message.getHeader().setStamp(connectedNode.getCurrentTime());
             publisher.publish(message);
             // There needs to be some time between messages in order to

--- a/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/MessagesBenchmark.java
+++ b/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/MessagesBenchmark.java
@@ -53,7 +53,7 @@ public class MessagesBenchmark extends AbstractNodeMain {
       @Override
       protected void loop() throws InterruptedException {
         geometry_msgs.TransformStamped message =
-            connectedNode.getTopicMessageFactory()
+            connectedNode.getDefaultMessageFactory()
                 .newFromType(geometry_msgs.TransformStamped._TYPE);
         message.getHeader().setFrameId("world");
         message.setChildFrameId("turtle");

--- a/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/PubsubBenchmark.java
+++ b/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/PubsubBenchmark.java
@@ -66,7 +66,7 @@ public class PubsubBenchmark extends AbstractNodeMain {
     tfPublisher = connectedNode.newPublisher("tf", tf2_msgs.TFMessage._TYPE);
     final tf2_msgs.TFMessage tfMessage = tfPublisher.newMessage();
     geometry_msgs.TransformStamped transformStamped =
-        connectedNode.getTopicMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
+        connectedNode.getDefaultMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
     tfMessage.getTransforms().add(transformStamped);
     connectedNode.executeCancellableLoop(new CancellableLoop() {
       @Override

--- a/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/TransformBenchmark.java
+++ b/rosjava_benchmarks/src/main/java/org/ros/rosjava_benchmarks/TransformBenchmark.java
@@ -51,11 +51,11 @@ public class TransformBenchmark extends AbstractNodeMain {
   @Override
   public void onStart(final ConnectedNode connectedNode) {
     final geometry_msgs.TransformStamped turtle1 =
-        connectedNode.getTopicMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
+        connectedNode.getDefaultMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
     turtle1.getHeader().setFrameId("world");
     turtle1.setChildFrameId("turtle1");
     final geometry_msgs.TransformStamped turtle2 =
-        connectedNode.getTopicMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
+        connectedNode.getDefaultMessageFactory().newFromType(geometry_msgs.TransformStamped._TYPE);
     turtle2.getHeader().setFrameId("world");
     turtle2.setChildFrameId("turtle2");
     final FrameTransformTree frameTransformTree = new FrameTransformTree();

--- a/rosjava_geometry/src/test/java/org/ros/rosjava_geometry/FrameTransformTreeTest.java
+++ b/rosjava_geometry/src/test/java/org/ros/rosjava_geometry/FrameTransformTreeTest.java
@@ -19,6 +19,7 @@ package org.ros.rosjava_geometry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.ros.internal.message.DefaultMessageFactory;
@@ -39,15 +40,21 @@ public class FrameTransformTreeTest {
 
   @Before
   public void before() {
-    frameTransformTree = new FrameTransformTree();
-    messageDefinitionProvider = new MessageDefinitionReflectionProvider();
-    messageFactory = new DefaultMessageFactory(messageDefinitionProvider);
+    this.frameTransformTree = new FrameTransformTree();
+    this.messageDefinitionProvider = new MessageDefinitionReflectionProvider();
+    this.messageFactory = new DefaultMessageFactory(messageDefinitionProvider);
+  }
+
+  @After
+  public void after(){
+     this.frameTransformTree = null;
+    this.messageDefinitionProvider = null;
+    this.messageFactory = null;
   }
 
   @Test
   public void testUpdateAndGet() {
-    FrameTransform frameTransform = new FrameTransform(Transform.identity(),
-        GraphName.of("foo"), GraphName.of("bar"), new Time());
+    final FrameTransform frameTransform = new FrameTransform(Transform.identity(),GraphName.of("foo"), GraphName.of("bar"), new Time());
     frameTransformTree.update(frameTransform);
     assertEquals(frameTransform, frameTransformTree.get("foo"));
   }

--- a/rosjava_test/src/main/java/org/ros/ParameterServerTestNode.java
+++ b/rosjava_test/src/main/java/org/ros/ParameterServerTestNode.java
@@ -63,9 +63,9 @@ public class ParameterServerTestNode extends AbstractNodeMain {
     ParameterTree param = connectedNode.getParameterTree();
 
     final RosLog rosLog = connectedNode.getLog();
-    MessageFactory topicMessageFactory = connectedNode.getTopicMessageFactory();
+    final MessageFactory defaultMessageFactory = connectedNode.getDefaultMessageFactory();
 
-    final std_msgs.String tilde_m = topicMessageFactory.newFromType(std_msgs.String._TYPE);
+    final std_msgs.String tilde_m = defaultMessageFactory.newFromType(std_msgs.String._TYPE);
     tilde_m.setData(param.getString(connectedNode.resolveName("~tilde").toString()));
     rosLog.info("tilde: " + tilde_m.getData());
 
@@ -76,22 +76,22 @@ public class ParameterServerTestNode extends AbstractNodeMain {
     NameResolver resolver = connectedNode.getResolver().newChild(paramNamespace);
     NameResolver setResolver = connectedNode.getResolver().newChild(targetNamespace);
 
-    final std_msgs.String string_m = topicMessageFactory.newFromType(std_msgs.String._TYPE);
+    final std_msgs.String string_m = defaultMessageFactory.newFromType(std_msgs.String._TYPE);
     string_m.setData(param.getString(resolver.resolve("string")));
     rosLog.info("string: " + string_m.getData());
-    final std_msgs.Int64 int_m = topicMessageFactory.newFromType(std_msgs.Int64._TYPE);
+    final std_msgs.Int64 int_m = defaultMessageFactory.newFromType(std_msgs.Int64._TYPE);
     int_m.setData(param.getInteger(resolver.resolve("int")));
     rosLog.info("int: " + int_m.getData());
 
-    final std_msgs.Bool bool_m = topicMessageFactory.newFromType(std_msgs.Bool._TYPE);
+    final std_msgs.Bool bool_m = defaultMessageFactory.newFromType(std_msgs.Bool._TYPE);
     bool_m.setData(param.getBoolean(resolver.resolve("bool")));
     rosLog.info("bool: " + bool_m.getData());
-    final std_msgs.Float64 float_m = topicMessageFactory.newFromType(std_msgs.Float64._TYPE);
+    final std_msgs.Float64 float_m = defaultMessageFactory.newFromType(std_msgs.Float64._TYPE);
     float_m.setData(param.getDouble(resolver.resolve("float")));
     rosLog.info("float: " + float_m.getData());
 
     final rosjava_test_msgs.Composite composite_m =
-        topicMessageFactory.newFromType(rosjava_test_msgs.Composite._TYPE);
+        defaultMessageFactory.newFromType(rosjava_test_msgs.Composite._TYPE);
     Map composite_map = param.getMap(resolver.resolve("composite"));
     composite_m.getA().setW((Double) ((Map) composite_map.get("a")).get("w"));
     composite_m.getA().setX((Double) ((Map) composite_map.get("a")).get("x"));
@@ -101,7 +101,7 @@ public class ParameterServerTestNode extends AbstractNodeMain {
     composite_m.getB().setY((Double) ((Map) composite_map.get("b")).get("y"));
     composite_m.getB().setZ((Double) ((Map) composite_map.get("b")).get("z"));
 
-    final rosjava_test_msgs.TestArrays list_m = topicMessageFactory.newFromType(rosjava_test_msgs.TestArrays._TYPE);
+    final rosjava_test_msgs.TestArrays list_m = defaultMessageFactory.newFromType(rosjava_test_msgs.TestArrays._TYPE);
     // only using the integer part for easier (non-float) comparison
     @SuppressWarnings("unchecked")
     List<Integer> list = (List<Integer>) param.getList(resolver.resolve("list"));

--- a/rosjava_test/src/main/java/org/ros/SlaveApiTestNode.java
+++ b/rosjava_test/src/main/java/org/ros/SlaveApiTestNode.java
@@ -71,12 +71,12 @@ public class SlaveApiTestNode extends AbstractNodeMain {
     connectedNode.executeCancellableLoop(new CancellableLoop() {
       @Override
       protected void loop() throws InterruptedException {
-        MessageFactory topicMessageFactory = connectedNode.getTopicMessageFactory();
-        std_msgs.String chatter = topicMessageFactory.newFromType(std_msgs.String._TYPE);
+        MessageFactory defaultMessageFactory = connectedNode.getDefaultMessageFactory();
+        std_msgs.String chatter = defaultMessageFactory.newFromType(std_msgs.String._TYPE);
         chatter.setData("hello " + System.currentTimeMillis());
         pub_string.publish(chatter);
 
-        std_msgs.Int64 num = topicMessageFactory.newFromType(std_msgs.Int64._TYPE);
+        std_msgs.Int64 num = defaultMessageFactory.newFromType(std_msgs.Int64._TYPE);
         num.setData(1);
         pub_int64_pubsub.publish(num);
         Thread.sleep(100);


### PR DESCRIPTION
Since TopicMessageFactory is practically a DefaultMessageFactory.
Reducing it usage to DefaultMessageFactory since the plan is to continue using DefaultMessageFactory.
Afterwards DefaultMessageFactory can be made final.