### PR TITLE
Exclude transitive loading of  message_generation

### DIFF
--- a/rosjava/build.gradle
+++ b/rosjava/build.gradle
@@ -19,7 +19,9 @@ plugins {
 }
 dependencies {
     api 'org.ros.rosjava_bootstrap:message_generation:noetic-0.1'
-    api 'org.ros.rosjava_messages:std_msgs:[0.5.9,0.5.11)'
+    api 'org.ros.rosjava_messages:std_msgs:[0.5.9,0.5.11)', {
+        exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+    }
 
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'io.netty:netty:3.10.6.Final'
@@ -34,15 +36,21 @@ dependencies {
     implementation project(':apache_xmlrpc_server')
     implementation project(':apache_xmlrpc_client')
 
-    implementation 'org.ros.rosjava_messages:rosgraph_msgs:[1.11,1.12)'
+    implementation 'org.ros.rosjava_messages:rosgraph_msgs:[1.11,1.12)', {
+        exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+    }
 
     implementation 'dnsjava:dnsjava:3.5.1'
 
     implementation 'commons-net:commons-net:3.8.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 
-    testImplementation 'org.ros.rosjava_messages:nav_msgs:[1.12,1.13)'
-    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'
+    testImplementation 'org.ros.rosjava_messages:nav_msgs:[1.12,1.13)', {
+        exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+    }
+    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0', {
+        exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+    }
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.2'

--- a/rosjava/src/test/java/org/ros/Assert.java
+++ b/rosjava/src/test/java/org/ros/Assert.java
@@ -23,9 +23,9 @@ import org.ros.namespace.GraphName;
 /**
  * @author damonkohler@google.com (Damon Kohler)
  */
-public class Assert {
+public final class Assert {
 
-  public static void assertGraphNameEquals(String name, GraphName graphName) {
+  public static final void assertGraphNameEquals(String name, GraphName graphName) {
     assertEquals(name, graphName.toString());
   }
 }

--- a/rosjava_benchmarks/build.gradle
+++ b/rosjava_benchmarks/build.gradle
@@ -21,6 +21,8 @@ mainClassName = 'org.ros.RosRun'
 dependencies {
   implementation project(':rosjava')
   implementation project(':rosjava_geometry')
-  implementation 'org.ros.rosjava_messages:tf2_msgs:[0.5,0.6)'
+  implementation 'org.ros.rosjava_messages:tf2_msgs:[0.5,0.6)', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
 
 }

--- a/rosjava_geometry/build.gradle
+++ b/rosjava_geometry/build.gradle
@@ -17,7 +17,9 @@ plugins{
   id 'java-library'
 }
 dependencies {
-  api 'org.ros.rosjava_messages:geometry_msgs:[1.12,1.13)'
+  api 'org.ros.rosjava_messages:geometry_msgs:[1.12,1.13)', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
   implementation 'com.google.guava:guava:31.1-jre'
   implementation project(':rosjava')
   testImplementation 'junit:junit:4.13.2'

--- a/rosjava_test/build.gradle
+++ b/rosjava_test/build.gradle
@@ -19,9 +19,15 @@ apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
 dependencies {
-  implementation 'org.ros.rosjava_messages:nav_msgs:[1.12,1.13)'
-  implementation 'org.ros.rosjava_messages:tf2_msgs:[0.5,0.6)'
-  implementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'
+  implementation 'org.ros.rosjava_messages:nav_msgs:[1.12,1.13)', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
+  implementation 'org.ros.rosjava_messages:tf2_msgs:[0.5,0.6)', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
+  implementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
   implementation project(':rosjava')
   implementation 'junit:junit:4.8.2'
 }

--- a/rosjava_tutorial_right_hand_rule/build.gradle
+++ b/rosjava_tutorial_right_hand_rule/build.gradle
@@ -20,7 +20,11 @@ mainClassName = 'org.ros.RosRun'
 
 dependencies {
   implementation project(':rosjava')
-  implementation 'org.ros.rosjava_messages:sensor_msgs:[1.12,1.13)'
-  implementation 'org.ros.rosjava_messages:geometry_msgs:[1.12,1.13)'
+  implementation 'org.ros.rosjava_messages:sensor_msgs:[1.12,1.13)', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
+  implementation 'org.ros.rosjava_messages:geometry_msgs:[1.12,1.13)', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
 }
 

--- a/rosjava_tutorial_services/build.gradle
+++ b/rosjava_tutorial_services/build.gradle
@@ -20,5 +20,7 @@ mainClassName = 'org.ros.RosRun'
 
 dependencies {
   implementation project(':rosjava')
-  implementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'
+  implementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0', {
+    exclude group: "org.ros.rosjava_bootstrap", module: "message_generation"
+  }
 }


### PR DESCRIPTION
Exclude transitive loading of  org.ros.rosjava_bootstrap:message_generation older versions, which bring up error during testing.
E.g. method not found Exception.
