### PR TITLE
Fix service response mix-ups under concurrent calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Changelog
 latest
 -----------------
 
+* Fixes:
+    - Fixed service response ordering (`SpyrosKou/rosjava_core#18 <https://github.com/SpyrosKou/rosjava_core/issues/18>`, `rosjava/rosjava_core#261 <https://github.com/rosjava/rosjava_core/issues/261>`)
+* Performance and concurrency:
+    - Reworked `ListenerGroup` dispatch to avoid idle thread-per-listener execution while preserving per-listener ordering and non-concurrent callback execution
+
 
 0.4.1.1 (2026-03-18)
 --------------------

--- a/rosjava/src/main/java/org/ros/concurrent/EventDispatcher.java
+++ b/rosjava/src/main/java/org/ros/concurrent/EventDispatcher.java
@@ -19,6 +19,7 @@ package org.ros.concurrent;
 
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
 
 /**
@@ -46,6 +47,25 @@ public final class EventDispatcher<T> {
     this.executorService = executorService;
   }
 
+  private boolean startDispatchIfNeeded() {
+    if (this.cancelled || this.dispatching || this.events.peekFirst() == null) {
+      return false;
+    }
+    this.dispatching = true;
+    return true;
+  }
+
+  private void executeDispatch() {
+    try {
+      this.executorService.execute(this::dispatch);
+    } catch (final RejectedExecutionException e) {
+      synchronized (mutex) {
+        this.dispatching = false;
+      }
+      throw e;
+    }
+  }
+
   /**
    * Submits a task to be processed by the dispatcher if the dispatcher is not cancelled.
    * Tasks are executed asynchronously in the order they are submitted.
@@ -53,17 +73,17 @@ public final class EventDispatcher<T> {
    * @param signalConsumer a consumer that will process the event, which operates on the listener of type {@code T}
    */
   public final void signal(final Consumer<T> signalConsumer) {
+    final boolean shouldDispatch;
     synchronized (mutex) {
       if (this.cancelled) {
         return;
       }
       this.events.addLast(signalConsumer);
-      if (this.dispatching) {
-        return;
-      }
-      this.dispatching = true;
+      shouldDispatch = this.startDispatchIfNeeded();
     }
-    this.executorService.execute(this::dispatch);
+    if (shouldDispatch) {
+      this.executeDispatch();
+    }
   }
 
   /**
@@ -83,8 +103,11 @@ public final class EventDispatcher<T> {
    * Thread interruptions or unexpected errors will not prevent the final cleanup steps from executing.
    */
   private final void dispatch() {
+    final Thread currentThread = Thread.currentThread();
+    Throwable failure = null;
+    boolean shouldDispatch = false;
     synchronized (this.mutex) {
-      this.dispatchThread = Thread.currentThread();
+      this.dispatchThread = currentThread;
     }
     try {
       while (true) {
@@ -100,11 +123,36 @@ public final class EventDispatcher<T> {
             return;
           }
         }
-        consumer.accept(this.listener);
+        try {
+          consumer.accept(this.listener);
+        } catch (final Throwable throwable) {
+          failure = throwable;
+          synchronized (this.mutex) {
+            this.dispatching = false;
+            shouldDispatch = this.startDispatchIfNeeded();
+          }
+          return;
+        }
       }
     } finally {
       synchronized (this.mutex) {
-        this.dispatchThread = null;
+        if (this.dispatchThread == currentThread) {
+          this.dispatchThread = null;
+        }
+      }
+      if (shouldDispatch) {
+        try {
+          this.executeDispatch();
+        } catch (final Throwable scheduleFailure) {
+          if (failure != null) {
+            failure.addSuppressed(scheduleFailure);
+          } else {
+            throw scheduleFailure;
+          }
+        }
+      }
+      if (failure != null) {
+        EventDispatcher.<RuntimeException>throwUnchecked(failure);
       }
     }
   }
@@ -112,7 +160,9 @@ public final class EventDispatcher<T> {
   /**
    * Cancels the event dispatching process and ensures proper cleanup of resources.
    *
-   * This method marks the dispatcher as*/
+   * This method marks the dispatcher as cancelled, clears queued work, and
+   * interrupts the active dispatch thread, if one is running.
+   */
   public final void cancel() {
     final Thread activeDispatchThread;
     synchronized (mutex) {
@@ -126,8 +176,12 @@ public final class EventDispatcher<T> {
     }
   }
 
-  public final T getListener()
-  {
+  public final T getListener() {
     return this.listener;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Throwable> void throwUnchecked(final Throwable throwable) throws E {
+    throw (E) throwable;
   }
 }

--- a/rosjava/src/main/java/org/ros/concurrent/ListenerGroup.java
+++ b/rosjava/src/main/java/org/ros/concurrent/ListenerGroup.java
@@ -36,12 +36,12 @@ import java.util.function.Consumer;
  */
 public final class ListenerGroup<T> {
 
-    private final static int DEFAULT_QUEUE_CAPACITY = 128;
+    private static final int DEFAULT_QUEUE_CAPACITY = 128;
 
     private final ExecutorService executorService;
-    private final List<EventDispatcher<T>> eventDispatchers = new CopyOnWriteArrayList();
+    private final List<EventDispatcher<T>> eventDispatchers = new CopyOnWriteArrayList<>();
 
-    public ListenerGroup(ExecutorService executorService) {
+    public ListenerGroup(final ExecutorService executorService) {
         this.executorService = executorService;
     }
 
@@ -67,7 +67,7 @@ public final class ListenerGroup<T> {
      * @return the {@link EventDispatcher} responsible for calling the specified
      * listener
      */
-    public final EventDispatcher<T> add(T listener) {
+    public final EventDispatcher<T> add(final T listener) {
         return add(listener, DEFAULT_QUEUE_CAPACITY);
     }
 
@@ -79,7 +79,7 @@ public final class ListenerGroup<T> {
      * @return a {@link Collection} of {@link EventDispatcher}s responsible for
      * calling the specified listeners
      */
-    public final void addAll(Collection<T> listeners, int limit) {
+    public final void addAll(final Collection<T> listeners, final int limit) {
         for (final T listener : listeners) {
             this.add(listener, limit);
         }
@@ -94,7 +94,7 @@ public final class ListenerGroup<T> {
      * @return a {@link Collection} of {@link EventDispatcher}s responsible for
      * calling the specified listeners
      */
-    public final void addAll(Collection<T> listeners) {
+    public final void addAll(final Collection<T> listeners) {
         this.addAll(listeners, DEFAULT_QUEUE_CAPACITY);
     }
 
@@ -115,14 +115,14 @@ public final class ListenerGroup<T> {
                 result = true;
             }
         }
-        return false;
+        return result;
     }
 
     /**
      * @return the number of listeners in the group
      */
     public final int size() {
-        return eventDispatchers.size();
+        return this.eventDispatchers.size();
     }
 
     /**
@@ -151,9 +151,9 @@ public final class ListenerGroup<T> {
      * limit, {@code false} otherwise
      * @throws InterruptedException
      */
-    public final boolean signal(final Consumer<T> signalConsumer, long timeout, TimeUnit unit)
+    public final boolean signal(final Consumer<T> signalConsumer, final long timeout, final TimeUnit unit)
             throws InterruptedException {
-        final List<EventDispatcher<T>> copy = Lists.newArrayList(eventDispatchers);
+        final List<EventDispatcher<T>> copy = Lists.newArrayList(this.eventDispatchers);
         final CountDownLatch latch = new CountDownLatch(copy.size());
         for (final EventDispatcher<T> eventDispatcher : copy) {
             eventDispatcher.signal(listener -> {

--- a/rosjava/src/main/java/org/ros/internal/node/service/ServiceRequestHandler.java
+++ b/rosjava/src/main/java/org/ros/internal/node/service/ServiceRequestHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc.
+ * Copyright (C) 2026 Spyros Koukas
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,12 +31,15 @@ import org.ros.message.MessageSerializer;
 import org.ros.node.service.ServiceResponseBuilder;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author damonkohler@google.com (Damon Kohler)
+ * @author Spyros Koukas
  */
 final class ServiceRequestHandler<T extends Message, S extends Message> extends SimpleChannelHandler {
 
@@ -46,12 +50,17 @@ final class ServiceRequestHandler<T extends Message, S extends Message> extends 
     private final MessageFactory messageFactory;
     private final ExecutorService executorService;
     private final MessageBufferPool messageBufferPool = new MessageBufferPool();
-    ;
+    // Service replies on a persistent connection must be emitted in request
+    // order because the client correlates them FIFO rather than by request id.
+    private final ConcurrentLinkedQueue<ChannelBuffer> pendingRequests = new ConcurrentLinkedQueue<>();
+    private final AtomicBoolean processingRequests = new AtomicBoolean(false);
 
-    public ServiceRequestHandler(ServiceDeclaration serviceDeclaration,
-                                 ServiceResponseBuilder<T, S> responseBuilder, MessageDeserializer<T> deserializer,
-                                 MessageSerializer<S> serializer, MessageFactory messageFactory,
-                                 ExecutorService executorService) {
+    public ServiceRequestHandler(final ServiceDeclaration serviceDeclaration,
+                                 final ServiceResponseBuilder<T, S> responseBuilder,
+                                 final MessageDeserializer<T> deserializer,
+                                 final MessageSerializer<S> serializer,
+                                 final MessageFactory messageFactory,
+                                 final ExecutorService executorService) {
         this.serviceDeclaration = serviceDeclaration;
         this.deserializer = deserializer;
         this.serializer = serializer;
@@ -60,24 +69,26 @@ final class ServiceRequestHandler<T extends Message, S extends Message> extends 
         this.executorService = executorService;
     }
 
-    private void handleRequest(ChannelBuffer requestBuffer, ChannelBuffer responseBuffer)
+    private final void handleRequest(final ChannelBuffer requestBuffer, final ChannelBuffer responseBuffer)
             throws ServiceException {
-      final T request = deserializer.deserialize(requestBuffer);
-      final S response = messageFactory.newFromType(serviceDeclaration.getType());
+      final T request = this.deserializer.deserialize(requestBuffer);
+      final S response = this.messageFactory.newFromType(this.serviceDeclaration.getType());
       this.responseBuilder.build(request, response);
       this.serializer.serialize(response, responseBuffer);
     }
 
-    private void handleSuccess(final ChannelHandlerContext ctx, ServiceServerResponse response,
-                               ChannelBuffer responseBuffer) {
+    private final void handleSuccess(final ChannelHandlerContext ctx,
+                                     final ServiceServerResponse response,
+                                     final ChannelBuffer responseBuffer) {
         response.setErrorCode(1);
         response.setMessageLength(responseBuffer.readableBytes());
         response.setMessage(responseBuffer);
         ctx.getChannel().write(response);
     }
 
-    private void handleError(final ChannelHandlerContext ctx, ServiceServerResponse response,
-                             String message) {
+    private final void handleError(final ChannelHandlerContext ctx,
+                                   final ServiceServerResponse response,
+                                   final String message) {
         response.setErrorCode(0);
         final ByteBuffer encodedMessage = StandardCharsets.US_ASCII.encode(message);
         response.setMessageLength(encodedMessage.limit());
@@ -85,25 +96,79 @@ final class ServiceRequestHandler<T extends Message, S extends Message> extends 
         ctx.getChannel().write(response);
     }
 
+    private static final String errorMessageFor(final Throwable throwable) {
+        final String message = throwable.getMessage();
+        if (message != null && !message.isEmpty()) {
+            return message;
+        }
+        return throwable.toString();
+    }
+
+    private final void processRequest(final ChannelHandlerContext ctx, final ChannelBuffer requestBuffer) {
+        final ServiceServerResponse response = new ServiceServerResponse();
+        final ChannelBuffer responseBuffer = messageBufferPool.acquire();
+
+        try {
+            handleRequest(requestBuffer, responseBuffer);
+            handleSuccess(ctx, response, responseBuffer);
+        } catch (final ServiceException ex) {
+            handleError(ctx, response, ex.getMessage());
+        } catch (final RuntimeException ex) {
+            handleError(ctx, response, errorMessageFor(ex));
+        } finally {
+            this.messageBufferPool.release(responseBuffer);
+        }
+    }
+
+    private final void scheduleRequestProcessing(final ChannelHandlerContext ctx) {
+        if (!this.processingRequests.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            this.executorService.execute(() -> drainPendingRequests(ctx));
+        } catch (final RejectedExecutionException e) {
+            this.processingRequests.set(false);
+            throw e;
+        }
+    }
+
+    private final void drainPendingRequests(final ChannelHandlerContext ctx) {
+        Throwable failure = null;
+        try {
+            while (true) {
+                final ChannelBuffer requestBuffer = this.pendingRequests.poll();
+                if (requestBuffer == null) {
+                    return;
+                }
+                processRequest(ctx, requestBuffer);
+            }
+        } catch (final Throwable throwable) {
+            failure = throwable;
+            throw throwable;
+        } finally {
+            this.processingRequests.set(false);
+            if (!this.pendingRequests.isEmpty()) {
+                try {
+                    this.scheduleRequestProcessing(ctx);
+                } catch (final RejectedExecutionException e) {
+                    if (failure != null) {
+                        failure.addSuppressed(e);
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+
     @Override
-    public void messageReceived(final ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+    public final void messageReceived(final ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
         // Although the ChannelHandlerContext is explicitly documented as being safe
         // to keep for later use, the MessageEvent is not. So, we make a defensive
         // copy of the ChannelBuffer.
         final ChannelBuffer requestBuffer = ((ChannelBuffer) e.getMessage()).copy();
-        this.executorService.execute(() -> {
-            final ServiceServerResponse response = new ServiceServerResponse();
-            final ChannelBuffer responseBuffer = messageBufferPool.acquire();
-
-            try {
-                handleRequest(requestBuffer, responseBuffer);
-                handleSuccess(ctx, response, responseBuffer);
-            } catch (final ServiceException ex) {
-                handleError(ctx, response, ex.getMessage());
-            }
-
-            this.messageBufferPool.release(responseBuffer);
-        });
+        this.pendingRequests.add(requestBuffer);
+        this.scheduleRequestProcessing(ctx);
         super.messageReceived(ctx, e);
     }
 }

--- a/rosjava/src/test/java/org/ros/concurrent/ListenerGroupTest.java
+++ b/rosjava/src/test/java/org/ros/concurrent/ListenerGroupTest.java
@@ -23,9 +23,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -49,8 +51,8 @@ public class ListenerGroupTest {
 
   @BeforeEach
   public void before() {
-    executorService = Executors.newCachedThreadPool();
-    listenerGroup = new ListenerGroup<Runnable>(executorService);
+    this.executorService = Executors.newCachedThreadPool();
+    this.listenerGroup = new ListenerGroup<Runnable>(this.executorService);
   }
 
   @AfterEach
@@ -66,7 +68,7 @@ public class ListenerGroupTest {
 
   @Test
   public void testOneListenerMultipleSignals() throws InterruptedException {
-    int numberOfSignals = 10;
+    final int numberOfSignals = 10;
     final CountDownLatch latch = new CountDownLatch(numberOfSignals);
     listenerGroup.add(new Runnable() {
       @Override
@@ -82,7 +84,7 @@ public class ListenerGroupTest {
 
   @Test
   public void testMultipleListenersMultipleSignals() throws InterruptedException {
-    int numberOfSignals = 10;
+    final int numberOfSignals = 10;
     final CountDownLatch latch1 = new CountDownLatch(numberOfSignals);
     final CountDownLatch latch2 = new CountDownLatch(numberOfSignals);
     listenerGroup.add(new Runnable() {
@@ -104,19 +106,33 @@ public class ListenerGroupTest {
     assertTrue(latch2.await(1, TimeUnit.SECONDS));
   }
 
+  @Test
+  public void testRemoveReturnsTrueForRegisteredListener() {
+    final Runnable listener = new Runnable() {
+      @Override
+      public void run() {
+      }
+    };
+
+    listenerGroup.add(listener);
+
+    assertTrue(listenerGroup.remove(listener));
+    assertEquals(0, listenerGroup.size());
+  }
+
   private interface CountingListener {
     void run(int count);
   }
 
   @Test
   public void testSignalOrder() throws InterruptedException {
-    int numberOfSignals = 100;
+    final int numberOfSignals = 100;
     final CountDownLatch latch = new CountDownLatch(numberOfSignals);
 
-    ListenerGroup<CountingListener> listenerGroup =
+    final ListenerGroup<CountingListener> listenerGroup =
         new ListenerGroup<CountingListener>(executorService);
     listenerGroup.add(new CountingListener() {
-      private AtomicInteger count = new AtomicInteger();
+      private final AtomicInteger count = new AtomicInteger();
 
       @Override
       public void run(int count) {
@@ -127,7 +143,7 @@ public class ListenerGroupTest {
           // Sleeping allows the queue to fill up a bit by slowing down the
           // consumer.
           Thread.sleep(5);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
         }
       }
     });
@@ -146,7 +162,7 @@ public class ListenerGroupTest {
     final CountDownLatch latch = new CountDownLatch(numberOfSignals);
     final List<Integer> actual = new ArrayList<Integer>();
 
-    ListenerGroup<CountingListener> orderedListenerGroup =
+    final ListenerGroup<CountingListener> orderedListenerGroup =
         new ListenerGroup<CountingListener>(executorService);
     orderedListenerGroup.add(new CountingListener() {
       @Override
@@ -180,7 +196,7 @@ public class ListenerGroupTest {
     final AtomicInteger maxConcurrentCallbacks = new AtomicInteger();
     final AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
 
-    ListenerGroup<Runnable> runnableListenerGroup = new ListenerGroup<Runnable>(executorService);
+    final ListenerGroup<Runnable> runnableListenerGroup = new ListenerGroup<Runnable>(executorService);
     runnableListenerGroup.add(new Runnable() {
       @Override
       public void run() {
@@ -191,7 +207,7 @@ public class ListenerGroupTest {
             failure.compareAndSet(null, new AssertionError("Listener callback overlapped."));
           }
           Thread.sleep(10);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
           failure.compareAndSet(null, e);
         } finally {
@@ -223,7 +239,7 @@ public class ListenerGroupTest {
         entered.countDown();
         try {
           release.await();
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
         }
       }
@@ -234,7 +250,7 @@ public class ListenerGroupTest {
         entered.countDown();
         try {
           release.await();
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
         }
       }
@@ -246,7 +262,7 @@ public class ListenerGroupTest {
       public void run() {
         try {
           completed.set(runnableListenerGroup.signal(listener -> listener.run(), 1, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
           completed.set(Boolean.FALSE);
         }
@@ -357,7 +373,7 @@ public class ListenerGroupTest {
               firstCallbackEntered.countDown();
               try {
                 releaseFirstCallback.await();
-              } catch (InterruptedException e) {
+              } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
               } finally {
                 firstCallbackFinished.countDown();
@@ -395,7 +411,7 @@ public class ListenerGroupTest {
         slowEntered.countDown();
         try {
           releaseSlow.await();
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
         }
       }
@@ -441,7 +457,72 @@ public class ListenerGroupTest {
     }
   }
 
-  private static boolean awaitThreadCount(String threadNamePrefix, int expectedCount, long timeoutMillis)
+  @Test
+  public void testRejectedDispatchDoesNotWedgeFutureSignals() throws InterruptedException {
+    final ExecutorService backingExecutor = Executors.newSingleThreadExecutor();
+    final RejectOnceExecutorService rejectOnceExecutor = new RejectOnceExecutorService(backingExecutor);
+    final ListenerGroup<Runnable> rejectingListenerGroup = new ListenerGroup<Runnable>(rejectOnceExecutor);
+    final CountDownLatch latch = new CountDownLatch(2);
+
+    try {
+      rejectingListenerGroup.add(new Runnable() {
+        @Override
+        public void run() {
+          latch.countDown();
+        }
+      });
+
+      boolean rejected = false;
+      try {
+        rejectingListenerGroup.signal(listener -> listener.run());
+      } catch (final RejectedExecutionException expected) {
+        rejected = true;
+      }
+
+      assertTrue(rejected);
+      rejectingListenerGroup.signal(listener -> listener.run());
+      assertTrue(latch.await(1, TimeUnit.SECONDS));
+    } finally {
+      rejectingListenerGroup.shutdown();
+      rejectOnceExecutor.shutdownNow();
+      rejectOnceExecutor.awaitTermination(1, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testListenerExceptionDoesNotWedgeFutureSignals() {
+    final DirectExecutorService directExecutorService = new DirectExecutorService();
+    final ListenerGroup<Runnable> directListenerGroup = new ListenerGroup<Runnable>(directExecutorService);
+    final AtomicInteger invocations = new AtomicInteger();
+
+    try {
+      directListenerGroup.add(new Runnable() {
+        @Override
+        public void run() {
+          if (invocations.getAndIncrement() == 0) {
+            throw new IllegalStateException("First callback failure.");
+          }
+        }
+      });
+
+      boolean firstSignalFailed = false;
+      try {
+        directListenerGroup.signal(listener -> listener.run());
+      } catch (final IllegalStateException expected) {
+        firstSignalFailed = true;
+      }
+
+      assertTrue(firstSignalFailed);
+      directListenerGroup.signal(listener -> listener.run());
+      assertEquals(2, invocations.get());
+    } finally {
+      directListenerGroup.shutdown();
+      directExecutorService.shutdownNow();
+    }
+  }
+
+  private static boolean awaitThreadCount(final String threadNamePrefix, final int expectedCount,
+      final long timeoutMillis)
       throws InterruptedException {
     final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
     while (System.nanoTime() < deadline) {
@@ -453,7 +534,7 @@ public class ListenerGroupTest {
     return countAliveThreads(threadNamePrefix) == expectedCount;
   }
 
-  private static int countAliveThreads(String threadNamePrefix) {
+  private static int countAliveThreads(final String threadNamePrefix) {
     int count = 0;
     for (Thread thread : Thread.getAllStackTraces().keySet()) {
       if (thread.isAlive() && thread.getName().startsWith(threadNamePrefix)) {
@@ -467,17 +548,97 @@ public class ListenerGroupTest {
     private final String threadNamePrefix;
     private final AtomicInteger threadCounter = new AtomicInteger();
 
-    private PrefixThreadFactory(String threadNamePrefix) {
+    private PrefixThreadFactory(final String threadNamePrefix) {
       this.threadNamePrefix = threadNamePrefix;
     }
 
     @Override
-    public Thread newThread(Runnable runnable) {
+    public Thread newThread(final Runnable runnable) {
       return new Thread(runnable, threadNamePrefix + "-" + threadCounter.incrementAndGet());
     }
   }
 
-  private static ExecutorService newTransientExecutor(String threadNamePrefix) {
+  private static final class RejectOnceExecutorService extends AbstractExecutorService {
+    private final ExecutorService delegate;
+    private final AtomicInteger executions = new AtomicInteger();
+
+    private RejectOnceExecutorService(final ExecutorService delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void shutdown() {
+      delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+      return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      if (executions.getAndIncrement() == 0) {
+        throw new RejectedExecutionException("Simulated rejection.");
+      }
+      delegate.execute(command);
+    }
+  }
+
+  private static final class DirectExecutorService extends AbstractExecutorService {
+    private volatile boolean shutdown;
+
+    @Override
+    public void shutdown() {
+      shutdown = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown = true;
+      return new ArrayList<Runnable>();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return shutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return shutdown;
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+      return shutdown;
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+      if (shutdown) {
+        throw new RejectedExecutionException("Executor already shut down.");
+      }
+      command.run();
+    }
+  }
+
+  private static ExecutorService newTransientExecutor(final String threadNamePrefix) {
     final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(0, 16,
         100, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(),
         new PrefixThreadFactory(threadNamePrefix));

--- a/rosjava/src/test/java/org/ros/internal/node/service/ServiceHandlingTest.java
+++ b/rosjava/src/test/java/org/ros/internal/node/service/ServiceHandlingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2026 Spyros Koukas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.ros.internal.node.service;
 
 
@@ -18,12 +34,17 @@ import rosjava_test_msgs.AddTwoIntsResponse;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.helpers.MessageFormatter;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
 /**
  * Class for running a multi-threaded service request
+ *
+ * @author Spyros Koukas
  */
 public class ServiceHandlingTest extends RosTest {
 
@@ -33,12 +54,12 @@ public class ServiceHandlingTest extends RosTest {
     @Test public void testServiceResponeOrder() throws Exception {
         final NodeConfiguration secondConfig = NodeConfiguration.newPrivate(rosCore.getUri());
         final MessageFactory messageFactory = secondConfig.getMessageFactory();
-        final CountDownLatch countDownLatch = new CountDownLatch(100);
         final String SERVICE_NAME = "test_service";
         final int NUM_THREADS = 10;
+        final CountDownLatch countDownLatch = new CountDownLatch(NUM_THREADS);
 
         // Create the anonymous node to test the server
-        AbstractNodeMain serverNode = new AbstractNodeMain() {
+        final AbstractNodeMain serverNode = new AbstractNodeMain() {
             @Override public GraphName getDefaultNodeName() {
                 return GraphName.of("server_node");
             }
@@ -46,12 +67,12 @@ public class ServiceHandlingTest extends RosTest {
             @Override public void onStart(final ConnectedNode connectedNode) {
 
                 // Setup Server
-                ServiceServer<AddTwoIntsRequest, AddTwoIntsResponse> testServer =
+                final ServiceServer<AddTwoIntsRequest, AddTwoIntsResponse> testServer =
                         connectedNode.newServiceServer(SERVICE_NAME, AddTwoInts._TYPE,
                                 new ServiceResponseBuilder<AddTwoIntsRequest, AddTwoIntsResponse>() {
 
                                     @Override
-                                    public void build(AddTwoIntsRequest req, AddTwoIntsResponse res) {
+                                    public void build(final AddTwoIntsRequest req, final AddTwoIntsResponse res) {
                                         res.setSum(req.getA() + req.getB());
                                     }
                                 });
@@ -61,7 +82,7 @@ public class ServiceHandlingTest extends RosTest {
         final List<ClientThread> threads = new LinkedList<>();
 
         // Create the anonymous node to test the server
-        AbstractNodeMain clientNode = new AbstractNodeMain() {
+        final AbstractNodeMain clientNode = new AbstractNodeMain() {
 
             @Override public GraphName getDefaultNodeName() {
                 return GraphName.of("client_node");
@@ -71,23 +92,23 @@ public class ServiceHandlingTest extends RosTest {
 
                 // Assert that the service was created
 
-                ServiceClient<AddTwoIntsRequest, AddTwoIntsResponse> serviceClient;
+                final ServiceClient<AddTwoIntsRequest, AddTwoIntsResponse> serviceClient;
                 try {
                     serviceClient = connectedNode.newServiceClient(SERVICE_NAME, AddTwoInts._TYPE);
-                    for(int i = 0; i < NUM_THREADS; i++) {
-                        ClientThread newThread = new ClientThread( i , i, countDownLatch, messageFactory,
+                    for (int i = 0; i < NUM_THREADS; i++) {
+                        final ClientThread newThread = new ClientThread(i, i, countDownLatch, messageFactory,
                                 SERVICE_NAME, serviceClient, connectedNode.getLog());
                         newThread.start();
                         threads.add(newThread);
                     }
-                } catch (org.ros.exception.ServiceNotFoundException e) {
+                } catch (final org.ros.exception.ServiceNotFoundException e) {
                     fail("Couldn't find service " + SERVICE_NAME);
                 }
             }
 
             @Override
-            public void onShutdown(Node node) {
-                for (ClientThread thread: threads) {
+            public void onShutdown(final Node node) {
+                for (final ClientThread thread : threads) {
                     thread.interrupt();
                 }
             }
@@ -100,10 +121,9 @@ public class ServiceHandlingTest extends RosTest {
         // Start the anonymous node to test the server
         nodeMainExecutor.execute(clientNode, secondConfig);
 
-        Thread.sleep(1000);
-        //assertTrue(countDownLatch.await(20, TimeUnit.SECONDS)); // Check if service calls were successful
+        assertTrue(countDownLatch.await(5, TimeUnit.SECONDS));
 
-        for(ClientThread a : threads) {
+        for (final ClientThread a : threads) {
             assertTrue(a.correct[0]);
         }
         // // Shutdown nodes
@@ -128,8 +148,10 @@ public class ServiceHandlingTest extends RosTest {
         final RosLog log;
         final boolean[] correct = new boolean[1];
 
-        ClientThread(int reqA, int reqB, CountDownLatch countDownLatch, MessageFactory messageFactory,
-                     String service, ServiceClient<AddTwoIntsRequest, AddTwoIntsResponse> serviceClient, RosLog log) {
+        ClientThread(final int reqA, final int reqB, final CountDownLatch countDownLatch,
+                     final MessageFactory messageFactory, final String service,
+                     final ServiceClient<AddTwoIntsRequest, AddTwoIntsResponse> serviceClient,
+                     final RosLog log) {
             this.a = reqA;
             this.b = reqB;
             this.countDownLatch = countDownLatch;
@@ -142,7 +164,7 @@ public class ServiceHandlingTest extends RosTest {
         }
 
         @Override
-        public void run(){
+        public void run() {
             // Build ros messages
             if (done[0]) {
 
@@ -154,16 +176,17 @@ public class ServiceHandlingTest extends RosTest {
                 req.setB(b);
 
                 serviceClient.call(req, new ServiceResponseListener<AddTwoIntsResponse>() {
-                    @Override public void onSuccess(AddTwoIntsResponse response) {
-                        log.info("Request: " + req.getA() + "+" + req.getB() + " Result: " + response.getSum());
-                        correct[0] = response.getSum() == (req.getA()+req.getB());
+                    @Override public void onSuccess(final AddTwoIntsResponse response) {
+                        log.info(MessageFormatter.arrayFormat("Request: {}+{} Result: {}",
+                                new Object[] {req.getA(), req.getB(), response.getSum()}).getMessage());
+                        correct[0] = response.getSum() == (req.getA() + req.getB());
                         countDownLatch.countDown();
                         done[0] = true;
                     }
 
                     @Override
-                    public void onFailure(RemoteException e) {
-                        fail("Service request failed for request " + a +"+"+ b);
+                    public void onFailure(final RemoteException e) {
+                        fail("Service request failed for request " + a + "+" + b);
                     }
                 });
             }

--- a/rosjava/src/test/java/org/ros/node/service/ServiceIntegrationTest.java
+++ b/rosjava/src/test/java/org/ros/node/service/ServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc.
+ * Copyright (C) 2026 Spyros Koukas
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,11 +25,13 @@ import org.ros.namespace.GraphName;
 import org.ros.node.AbstractNodeMain;
 import org.ros.node.ConnectedNode;
 import org.ros.node.ServiceClientNode;
+import rosjava_test_msgs.AddTwoIntsRequest;
 import rosjava_test_msgs.AddTwoIntsResponse;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static junit.framework.Assert.*;
 
@@ -36,6 +39,7 @@ import static junit.framework.Assert.*;
 
 /**
  * @author damonkohler@google.com (Damon Kohler)
+ * @author Spyros Koukas
  */
 public class ServiceIntegrationTest extends RosTest {
 
@@ -55,7 +59,7 @@ public class ServiceIntegrationTest extends RosTest {
 
             @Override
             public void onStart(final ConnectedNode connectedNode) {
-                ServiceServer<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceServer =
+                final ServiceServer<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceServer =
                         connectedNode
                                 .newServiceServer(
                                         SERVICE_NAME,
@@ -65,7 +69,7 @@ public class ServiceIntegrationTest extends RosTest {
                     connectedNode.newServiceServer(SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE, (a, b) -> {
                     });
                     fail();
-                } catch (DuplicateServiceException e) {
+                } catch (final DuplicateServiceException e) {
                     // Only one ServiceServer with a given name can be created.
                 }
                 serviceServer.addListener(countDownServiceServerListener);
@@ -83,7 +87,7 @@ public class ServiceIntegrationTest extends RosTest {
 
             @Override
             public void onStart(ConnectedNode connectedNode) {
-                ServiceClient<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceClient;
+                final ServiceClient<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceClient;
                 try {
                     serviceClient = connectedNode.newServiceClient(SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
                     // Test that requesting another client for the same service returns
@@ -91,7 +95,7 @@ public class ServiceIntegrationTest extends RosTest {
                     ServiceClient<?, ?> duplicate =
                             connectedNode.newServiceClient(SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
                     assertEquals(serviceClient, duplicate);
-                } catch (ServiceNotFoundException e) {
+                } catch (final ServiceNotFoundException e) {
                     throw new RosRuntimeException(e);
                 }
                 final rosjava_test_msgs.AddTwoIntsRequest request = serviceClient.newMessage();
@@ -107,7 +111,7 @@ public class ServiceIntegrationTest extends RosTest {
                         }
 
                         @Override
-                        public void onFailure(RemoteException e) {
+                        public void onFailure(final RemoteException e) {
                             throw new RuntimeException(e);
                         }
                     });
@@ -125,7 +129,7 @@ public class ServiceIntegrationTest extends RosTest {
                         }
 
                         @Override
-                        public void onFailure(RemoteException e) {
+                        public void onFailure(final RemoteException e) {
                             throw new RuntimeException(e);
                         }
                     });
@@ -134,6 +138,305 @@ public class ServiceIntegrationTest extends RosTest {
         }, nodeConfiguration);
 
         assertTrue(latch.await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testPersistentServiceConnectionPreservesOrderingDeterministically() throws Exception {
+        final CountDownServiceServerListener<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> countDownServiceServerListener =
+                CountDownServiceServerListener.newDefault();
+        nodeMainExecutor.execute(new AbstractNodeMain() {
+            @Override
+            public GraphName getDefaultNodeName() {
+                return GraphName.of(SERVER_NAME + "_ordered");
+            }
+
+            @Override
+            public void onStart(final ConnectedNode connectedNode) {
+                final ServiceServer<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceServer =
+                        connectedNode.newServiceServer(
+                                SERVICE_NAME,
+                                rosjava_test_msgs.AddTwoInts._TYPE,
+                                (request, response) -> {
+                                    if (request.getA() == 1) {
+                                        try {
+                                            Thread.sleep(200);
+                                        } catch (final InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                    response.setSum(request.getA() + request.getB());
+                                });
+                serviceServer.addListener(countDownServiceServerListener);
+            }
+        }, nodeConfiguration);
+
+        assertTrue(countDownServiceServerListener.awaitMasterRegistrationSuccess(1, TimeUnit.SECONDS));
+
+        final CountDownLatch latch = new CountDownLatch(2);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        nodeMainExecutor.execute(new AbstractNodeMain() {
+            @Override
+            public GraphName getDefaultNodeName() {
+                return GraphName.of(CLIENT + "_ordered");
+            }
+
+            @Override
+            public void onStart(ConnectedNode connectedNode) {
+                final ServiceClient<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceClient;
+                try {
+                    serviceClient = connectedNode.newServiceClient(SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
+                } catch (final ServiceNotFoundException e) {
+                    failure.compareAndSet(null, e);
+                    while (latch.getCount() > 0) {
+                        latch.countDown();
+                    }
+                    return;
+                }
+
+                final AddTwoIntsRequest firstRequest = serviceClient.newMessage();
+                firstRequest.setA(1);
+                firstRequest.setB(1);
+                serviceClient.call(firstRequest, new ServiceResponseListener<>() {
+                    @Override
+                    public void onSuccess(AddTwoIntsResponse response) {
+                        if (response.getSum() != 2) {
+                            failure.compareAndSet(null,
+                                    new AssertionError("Expected first response sum 2 but was " + response.getSum()));
+                        }
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(final RemoteException e) {
+                        failure.compareAndSet(null, e);
+                        latch.countDown();
+                    }
+                });
+
+                final AddTwoIntsRequest secondRequest = serviceClient.newMessage();
+                secondRequest.setA(2);
+                secondRequest.setB(2);
+                serviceClient.call(secondRequest, new ServiceResponseListener<>() {
+                    @Override
+                    public void onSuccess(AddTwoIntsResponse response) {
+                        if (response.getSum() != 4) {
+                            failure.compareAndSet(null,
+                                    new AssertionError("Expected second response sum 4 but was " + response.getSum()));
+                        }
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(final RemoteException e) {
+                        failure.compareAndSet(null, e);
+                        latch.countDown();
+                    }
+                });
+            }
+        }, nodeConfiguration);
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        if (failure.get() != null) {
+            fail(failure.get().toString());
+        }
+    }
+
+    @Test
+    public void testSeparatePersistentServiceClientsRemainIndependent() throws Exception {
+        final CountDownServiceServerListener<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> countDownServiceServerListener =
+                CountDownServiceServerListener.newDefault();
+        final CountDownLatch slowRequestEntered = new CountDownLatch(1);
+        final CountDownLatch releaseSlowRequest = new CountDownLatch(1);
+
+        nodeMainExecutor.execute(new AbstractNodeMain() {
+            @Override
+            public GraphName getDefaultNodeName() {
+                return GraphName.of(SERVER_NAME + "_parallel");
+            }
+
+            @Override
+            public void onStart(final ConnectedNode connectedNode) {
+                ServiceServer<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceServer =
+                        connectedNode.newServiceServer(
+                                SERVICE_NAME,
+                                rosjava_test_msgs.AddTwoInts._TYPE,
+                                (request, response) -> {
+                                    if (request.getA() == 1) {
+                                        slowRequestEntered.countDown();
+                                        try {
+                                            releaseSlowRequest.await();
+                                        } catch (final InterruptedException e) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                    }
+                                    response.setSum(request.getA() + request.getB());
+                                });
+                serviceServer.addListener(countDownServiceServerListener);
+            }
+        }, nodeConfiguration);
+
+        assertTrue(countDownServiceServerListener.awaitMasterRegistrationSuccess(1, TimeUnit.SECONDS));
+
+        final ServiceClientNode<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> client1 =
+                new ServiceClientNode<>(SERVER_NAME + CLIENT + "_parallel_1", SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
+        final ServiceClientNode<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> client2 =
+                new ServiceClientNode<>(SERVER_NAME + CLIENT + "_parallel_2", SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
+
+        nodeMainExecutor.execute(client1, nodeConfiguration);
+        nodeMainExecutor.execute(client2, nodeConfiguration);
+        assertTrue(client1.awaitConnection(1, TimeUnit.SECONDS));
+        assertTrue(client2.awaitConnection(1, TimeUnit.SECONDS));
+
+        final CountDownLatch fastCompleted = new CountDownLatch(1);
+        final CountDownLatch slowCompleted = new CountDownLatch(1);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        final AddTwoIntsRequest slowRequest = client1.getServiceClient().newMessage();
+        slowRequest.setA(1);
+        slowRequest.setB(1);
+        client1.getServiceClient().call(slowRequest, new ServiceResponseListener<>() {
+            @Override
+            public void onSuccess(AddTwoIntsResponse response) {
+                if (response.getSum() != 2) {
+                    failure.compareAndSet(null,
+                            new AssertionError("Expected slow response sum 2 but was " + response.getSum()));
+                }
+                slowCompleted.countDown();
+            }
+
+            @Override
+            public void onFailure(RemoteException e) {
+                failure.compareAndSet(null, e);
+                slowCompleted.countDown();
+            }
+        });
+
+        assertTrue(slowRequestEntered.await(1, TimeUnit.SECONDS));
+
+        final AddTwoIntsRequest fastRequest = client2.getServiceClient().newMessage();
+        fastRequest.setA(2);
+        fastRequest.setB(2);
+        client2.getServiceClient().call(fastRequest, new ServiceResponseListener<>() {
+            @Override
+            public void onSuccess(AddTwoIntsResponse response) {
+                if (response.getSum() != 4) {
+                    failure.compareAndSet(null,
+                            new AssertionError("Expected fast response sum 4 but was " + response.getSum()));
+                }
+                fastCompleted.countDown();
+            }
+
+            @Override
+            public void onFailure(RemoteException e) {
+                failure.compareAndSet(null, e);
+                fastCompleted.countDown();
+            }
+        });
+
+        assertTrue(fastCompleted.await(1, TimeUnit.SECONDS));
+        releaseSlowRequest.countDown();
+        assertTrue(slowCompleted.await(1, TimeUnit.SECONDS));
+        if (failure.get() != null) {
+            fail(failure.get().toString());
+        }
+    }
+
+    @Test
+    public void testPersistentServiceConnectionRecoversFromUncheckedServerFailure() throws Exception {
+        final CountDownServiceServerListener<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> countDownServiceServerListener =
+                CountDownServiceServerListener.newDefault();
+        nodeMainExecutor.execute(new AbstractNodeMain() {
+            @Override
+            public GraphName getDefaultNodeName() {
+                return GraphName.of(SERVER_NAME + "_runtime_failure");
+            }
+
+            @Override
+            public void onStart(final ConnectedNode connectedNode) {
+                ServiceServer<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceServer =
+                        connectedNode.newServiceServer(
+                                SERVICE_NAME,
+                                rosjava_test_msgs.AddTwoInts._TYPE,
+                                (request, response) -> {
+                                    if (request.getA() == 1) {
+                                        throw new IllegalStateException("boom");
+                                    }
+                                    response.setSum(request.getA() + request.getB());
+                                });
+                serviceServer.addListener(countDownServiceServerListener);
+            }
+        }, nodeConfiguration);
+
+        assertTrue(countDownServiceServerListener.awaitMasterRegistrationSuccess(1, TimeUnit.SECONDS));
+
+        final CountDownLatch latch = new CountDownLatch(2);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        nodeMainExecutor.execute(new AbstractNodeMain() {
+            @Override
+            public GraphName getDefaultNodeName() {
+                return GraphName.of(CLIENT + "_runtime_failure");
+            }
+
+            @Override
+            public void onStart(ConnectedNode connectedNode) {
+                final ServiceClient<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceClient;
+                try {
+                    serviceClient = connectedNode.newServiceClient(SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
+                } catch (final ServiceNotFoundException e) {
+                    failure.compareAndSet(null, e);
+                    while (latch.getCount() > 0) {
+                        latch.countDown();
+                    }
+                    return;
+                }
+
+                final AddTwoIntsRequest failingRequest = serviceClient.newMessage();
+                failingRequest.setA(1);
+                failingRequest.setB(1);
+                serviceClient.call(failingRequest, new ServiceResponseListener<>() {
+                    @Override
+                    public void onSuccess(AddTwoIntsResponse response) {
+                        failure.compareAndSet(null,
+                                new AssertionError("Expected unchecked server failure to produce onFailure."));
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(RemoteException e) {
+                        if (e.getMessage() == null || !e.getMessage().contains("boom")) {
+                            failure.compareAndSet(null,
+                                    new AssertionError("Expected failure message to contain boom but was: " + e.getMessage()));
+                        }
+                        latch.countDown();
+                    }
+                });
+
+                final AddTwoIntsRequest succeedingRequest = serviceClient.newMessage();
+                succeedingRequest.setA(2);
+                succeedingRequest.setB(2);
+                serviceClient.call(succeedingRequest, new ServiceResponseListener<>() {
+                    @Override
+                    public void onSuccess(AddTwoIntsResponse response) {
+                        if (response.getSum() != 4) {
+                            failure.compareAndSet(null,
+                                    new AssertionError("Expected second response sum 4 but was " + response.getSum()));
+                        }
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(RemoteException e) {
+                        failure.compareAndSet(null, e);
+                        latch.countDown();
+                    }
+                });
+            }
+        }, nodeConfiguration);
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        if (failure.get() != null) {
+            fail(failure.get().toString());
+        }
     }
 
     /**
@@ -165,7 +468,7 @@ public class ServiceIntegrationTest extends RosTest {
                                     rosjava_test_msgs.AddTwoInts._TYPE,
                                     (request, response) -> response.setSum(request.getA() + request.getB()));
                     serviceServer1.addListener(countDownServiceServerListener);
-                } catch (DuplicateServiceException e) {
+                } catch (final DuplicateServiceException e) {
                     // Only one ServiceServer with a given name can be created.
                     dualServiceDeclarationDetected.incrementAndGet();
                 }
@@ -176,7 +479,7 @@ public class ServiceIntegrationTest extends RosTest {
                                     rosjava_test_msgs.AddTwoInts._TYPE,
                                     (request, response) -> response.setSum(request.getA() + request.getB()));
                     serviceServer1.addListener(countDownServiceServerListener);
-                } catch (DuplicateServiceException e) {
+                } catch (final DuplicateServiceException e) {
                     // Only one ServiceServer with a given name can be created.
                     dualServiceDeclarationDetected.incrementAndGet();
                 }
@@ -224,7 +527,7 @@ public class ServiceIntegrationTest extends RosTest {
                                     rosjava_test_msgs.AddTwoInts._TYPE,
                                     (request, response) -> response.setSum(1));
                     serviceServer1.addListener(countDownServiceServerListener);
-                } catch (DuplicateServiceException e) {
+                } catch (final DuplicateServiceException e) {
                     // Only one ServiceServer with a given name can be created.
 
                 }
@@ -269,7 +572,7 @@ public class ServiceIntegrationTest extends RosTest {
                                     rosjava_test_msgs.AddTwoInts._TYPE,
                                     (request, response) -> response.setSum(2));
                     serviceServer1.addListener(countDownServiceServerListener);
-                } catch (DuplicateServiceException e) {
+                } catch (final DuplicateServiceException e) {
                     // Only one ServiceServer with a given name can be created.
 
                 }
@@ -364,7 +667,7 @@ public class ServiceIntegrationTest extends RosTest {
                 ServiceClient<rosjava_test_msgs.AddTwoIntsRequest, rosjava_test_msgs.AddTwoIntsResponse> serviceClient;
                 try {
                     serviceClient = connectedNode.newServiceClient(SERVICE_NAME, rosjava_test_msgs.AddTwoInts._TYPE);
-                } catch (ServiceNotFoundException e) {
+                } catch (final ServiceNotFoundException e) {
                     throw new RosRuntimeException(e);
                 }
                 rosjava_test_msgs.AddTwoIntsRequest request = serviceClient.newMessage();


### PR DESCRIPTION
Fix service response ordering under concurrent calls and add shutdown regression coverage.
## Related issues:
### Upstream: [rosjava/rosjava_core#261](https://github.com/rosjava/rosjava_core/issues/261)
### Current repo: [SpyrosKou/rosjava_core#18](https://github.com/SpyrosKou/rosjava_core/issues/18)